### PR TITLE
Erreur dans un exemple

### DIFF
--- a/pages/articles/impatient-C.html
+++ b/pages/articles/impatient-C.html
@@ -674,7 +674,7 @@ Voici ce qu'il se passe ici :
       </li>
     <li>Exemple :
       <div class="code"><pre>        i = 1;
-	<span class="cyan">if</span> ((i++ == 2) || (++i == 3))
+	<span class="cyan">if</span> ((i++ == 2) || (++i == 2))
 	  i -= 2;</pre></div>
       <ul>
 	<li>(i++ == 2).<br />


### PR DESCRIPTION
L677 :  ((i++ == 2) || (++i == 2)) au lieu de  ((i++ == 2) || (++i == 3))
